### PR TITLE
Test prepare

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -25,6 +25,13 @@ cfr. [keepachangelog.com](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
+## [v2.3.8] - 2024-05-13
+
+### Fixed
+
+- Fixed the prepare script in package.json, so it will work when installed as a dependency,
+  and when installed locally for developement (in which case the git-hooks will be installed)
+
 ## [v2.3.7] - 2024-03-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8489,7 +8489,7 @@
     "sri4node": {
       "version": "git+ssh://git@github.com/katholiek-onderwijs-vlaanderen/sri4node.git#87e24fbb756ac5f281c06a203b448dce9f07f586",
       "dev": true,
-      "from": "sri4node@katholiek-onderwijs-vlaanderen/sri4node",
+      "from": "sri4node@github:katholiek-onderwijs-vlaanderen/sri4node",
       "requires": {
         "@types/busboy": "^1.5.0",
         "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "docker compose -f test/docker/docker-compose.yml down --remove-orphans --rmi=local && docker compose -f test/docker/docker-compose.yml up --wait postgres && docker compose -f test/docker/docker-compose.yml logs && mocha",
     "test:skipintegrationtests": "SKIP_INTEGRATION_TESTS=true mocha",
-    "prepare": "echo \"\n\n----------> $(pwd)\nls .git\n-------\n$(ls .git)\n\n\"\n(\n    case \"$(pwd)\" in\n        *\"/node_modules\"*) echo \"Not setting git core.hooksPath (installed as a dependency)\";;\n        *) git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";;\n    esac\n  )\n"
+    "prepare": "if [ -d .git ]; then git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\"; else echo \"Not setting git core.hooksPath (installed as a dependency)\"; fi"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "docker compose -f test/docker/docker-compose.yml down --remove-orphans --rmi=local && docker compose -f test/docker/docker-compose.yml up --wait postgres && docker compose -f test/docker/docker-compose.yml logs && mocha",
     "test:skipintegrationtests": "SKIP_INTEGRATION_TESTS=true mocha",
-    "prepare": "(\n    case \"$(pwd)\" in\n        *\"/node_modules\"*) echo \"Not setting git core.hooksPath (installed as a dependency)\";;\n        *) git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";;\n    esac\n  )\n"
+    "prepare": "echo \"\n\n----------> $(pwd)\n\n\"\n(\n    case \"$(pwd)\" in\n        *\"/node_modules\"*) echo \"Not setting git core.hooksPath (installed as a dependency)\";;\n        *) git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";;\n    esac\n  )\n"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "docker compose -f test/docker/docker-compose.yml down --remove-orphans --rmi=local && docker compose -f test/docker/docker-compose.yml up --wait postgres && docker compose -f test/docker/docker-compose.yml logs && mocha",
     "test:skipintegrationtests": "SKIP_INTEGRATION_TESTS=true mocha",
-    "prepare": "if [ -d .git ]; then git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\"; else echo \"Not setting git core.hooksPath (installed as a dependency)\"; fi"
+    "prepare": "if [ -d .git ]; then\n  git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";\nelse\n  echo \"Not setting git core.hooksPath (installed as a dependency)\";\nfi\n"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "docker compose -f test/docker/docker-compose.yml down --remove-orphans --rmi=local && docker compose -f test/docker/docker-compose.yml up --wait postgres && docker compose -f test/docker/docker-compose.yml logs && mocha",
     "test:skipintegrationtests": "SKIP_INTEGRATION_TESTS=true mocha",
-    "prepare": "echo \"\n\n----------> $(pwd)\n\n\"\n(\n    case \"$(pwd)\" in\n        *\"/node_modules\"*) echo \"Not setting git core.hooksPath (installed as a dependency)\";;\n        *) git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";;\n    esac\n  )\n"
+    "prepare": "echo \"\n\n----------> $(pwd)\nls .git\n-------\n$(ls .git)\n\n\"\n(\n    case \"$(pwd)\" in\n        *\"/node_modules\"*) echo \"Not setting git core.hooksPath (installed as a dependency)\";;\n        *) git config core.hooksPath ./git-hooks && echo \"git core.hooksPath has been set to: $(git config core.hooksPath)\";;\n    esac\n  )\n"
   },
   "dependencies": {
     "fetch-retry": "^5.0.6",


### PR DESCRIPTION
Fixed the prepare script in package.json, so it will work when installed as a dependency,
and when installed locally for developement (in which case the git-hooks will be installed)

Added release notes so we can hopefully release v2.3.8 on Monday 13/05/2024